### PR TITLE
update supernode references of 1.0.1 to 1.0.4

### DIFF
--- a/Graft_Supernode_Mainnet_Simple-step-by-step-setup-instructions-for-non-Linux-users_v1.7.md
+++ b/Graft_Supernode_Mainnet_Simple-step-by-step-setup-instructions-for-non-Linux-users_v1.7.md
@@ -90,7 +90,7 @@ _by: yidakee (aka el_duderino_007)_
 
 ![5](easy-guide-mainnet/5.png)
 
-* Next, lets enter the directory where the GraftNetwork binaries where decompressed into, and have a look inside. You will see there is a `graft-supernode` binary inside - do not use this one! The actual Supernode binary is inside /root/supernode.1.0.1.ubuntu-18.04.x64/
+* Next, lets enter the directory where the GraftNetwork binaries where decompressed into, and have a look inside. You will see there is a `graft-supernode` binary inside - do not use this one! The actual Supernode binary is inside /root/supernode.1.0.4.ubuntu-18.04.x64/
 
 ````bash
     cd GraftNetwork_1.7.5
@@ -107,7 +107,7 @@ _by: yidakee (aka el_duderino_007)_
     cd
 ````
 
-Here is a handy Linux trick. Instead of writing `cd supernode.1.0.1.ubuntu-18.04.x64` try just typing `cd supe`and then press Tab. Linux is smart enough to guess what you mean and will autocomplete for you ;) 
+Here is a handy Linux trick. Instead of writing `cd supernode.1.0.4.ubuntu-18.04.x64` try just typing `cd supe`and then press Tab. Linux is smart enough to guess what you mean and will autocomplete for you ;) 
 
 ### Great! We’ve managed to install everything.
 


### PR DESCRIPTION
In the [Graft_Supernode_Mainnet_Simple-step-by-step-setup-instructions-for-non-Linux-users_v1.7](https://github.com/graft-community/docs/blob/master/Graft_Supernode_Mainnet_Simple-step-by-step-setup-instructions-for-non-Linux-users_v1.7.md), there were a couple instances still referencing a supernode version of `1.0.1` that have been updated to `1.0.4`